### PR TITLE
fix: Correct state access in components

### DIFF
--- a/components/Inventory.tsx
+++ b/components/Inventory.tsx
@@ -38,7 +38,12 @@ const RewardItem = ({ reward }: { reward: RealWorldRewardType }) => (
 
 
 const Inventory = () => {
-    const { inventory, realWorldRewards } = useAppContext();
+    const { state: { inventory, realWorldRewards } } = useAppContext();
+
+    // This check is defensive. The parent page should prevent rendering if inventory is null.
+    if (!inventory) {
+        return null;
+    }
 
     return (
         <div className="w-full max-w-2xl mx-auto bg-black/30 backdrop-blur-md rounded-lg shadow-lg border border-cyan-500/20 p-6 text-white font-sans mt-8">

--- a/components/SkillsWindow.tsx
+++ b/components/SkillsWindow.tsx
@@ -34,7 +34,7 @@ const Saga = ({ saga }: { saga: SagaType }) => (
 
 
 const SkillsWindow = () => {
-  const { sagas } = useAppContext();
+  const { state: { sagas } } = useAppContext();
 
   return (
     <div className="w-full max-w-2xl mx-auto bg-black/30 backdrop-blur-md rounded-lg shadow-lg border border-cyan-500/20 p-6 text-white font-sans mt-8">

--- a/components/StatusWindow.tsx
+++ b/components/StatusWindow.tsx
@@ -21,7 +21,9 @@ const CoreStat = ({ name, value }: { name: string; value: number }) => (
 );
 
 const StatusWindow = () => {
-  const { userProfile } = useAppContext();
+  const { state: { userProfile } } = useAppContext();
+
+  if (!userProfile) return null; // Or a loading skeleton
 
   return (
     <div className="w-full max-w-2xl mx-auto bg-black/30 backdrop-blur-md rounded-lg shadow-lg border border-cyan-500/20 p-6 text-white font-sans">

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "autoprefixer": "^10.4.19",
     "eslint": "^8",
     "eslint-config-next": "14.2.3"
   }


### PR DESCRIPTION
Corrects how components access data from the `useAppContext` hook.

Previously, components were attempting to destructure data directly from the context, e.g., `const { userProfile } = useAppContext()`. This is incorrect, as the context provides an object with a `state` property.

The fix changes the destructuring to `const { state: { userProfile } } = useAppContext()`, which correctly accesses the nested state object. This resolves the runtime error "TypeError: can't access property 'level', userProfile is undefined".